### PR TITLE
Refactored Vec4i and BlockPos4 to extend Vec3i and BlockPos respectively

### DIFF
--- a/src/main/java/com/gmail/inayakitorikhurram/fdmc/math/BlockPos4.java
+++ b/src/main/java/com/gmail/inayakitorikhurram/fdmc/math/BlockPos4.java
@@ -1,19 +1,31 @@
 package com.gmail.inayakitorikhurram.fdmc.math;
 
-import com.gmail.inayakitorikhurram.fdmc.math.Direction4.Axis4;
+import com.gmail.inayakitorikhurram.fdmc.FDMCConstants;
 import net.minecraft.util.math.*;
 import org.jetbrains.annotations.Unmodifiable;
 
 @Unmodifiable
-public class BlockPos4 extends Vec4i {
+public class BlockPos4 extends BlockPos implements Vec4i<BlockPos4> {
     public static final BlockPos4 ORIGIN;
+    private int w;
 
-    public BlockPos4(int i, int j, int k, int l) {
-        super(i, j, k, l);
+    //util for doing some calculations before super constructor call
+    private static int convertX(Vec3i vec3i) {
+        int x = vec3i.getX();
+        if (vec3i instanceof Vec4i<?>) {
+            return x;
+        }
+        int w = (int)(Math.floor(0.5 + (x + 0d)/ FDMCConstants.STEP_DISTANCE));
+        return x - w * FDMCConstants.STEP_DISTANCE;
     }
 
-    public BlockPos4(double d, double e, double f, double g) {
-        super(d, e, f, g);
+    public BlockPos4(int x, int y, int z, int w) {
+        super(x, y, z);
+        this.w = w;
+    }
+
+    public BlockPos4(double x, double y, double z, double w) {
+        this(MathHelper.floor(x), MathHelper.floor(y), MathHelper.floor(z), MathHelper.floor(w));
     }
 
     public BlockPos4(Vec4d pos) {
@@ -24,165 +36,44 @@ public class BlockPos4 extends Vec4i {
         this(pos.getX(), pos.getY(), pos.getZ(), pos.getW());
     }
 
-    public BlockPos4(Vec4i pos) {
+    public BlockPos4(Vec4i<?> pos) {
         this(pos.getX(), pos.getY(), pos.getZ(), pos.getW());
     }
 
-    public BlockPos4(BlockPos pos3) {
-        super(pos3.getX(), pos3.getY(), pos3.getZ());
+    public BlockPos4(Vec3i vec3i) {
+        super(convertX(vec3i), vec3i.getY(), vec3i.getZ());
+        if (vec3i instanceof Vec4i<?>) {
+            this.w = ((Vec4i<?>) vec3i).getW();
+        } else {
+            this.w = (int)(Math.floor(0.5 + (vec3i.getX() + 0d)/ FDMCConstants.STEP_DISTANCE));
+        }
     }
 
+    @Override
+    public BlockPos4 newInstance(int x, int y, int z, int w) {
+        return new BlockPos4(x, y, z, w);
+    }
+
+    @Override
     public BlockPos toPos3() {
-        return new BlockPos(super.toPos3());
+        return new BlockPos(Vec4i.super.toPos3());
     }
 
-    public static long removeChunkSectionLocalY(long y) {
-        return y & -16L;
+    @Override
+    public int getW() {
+        return w;
     }
 
-    public BlockPos4 add(double dx, double dy, double dz, double dw) {
-        return dx == 0.0 && dy == 0.0 && dz == 0.0 && dw == 0.0 ? this :
-                new BlockPos4(
-                        (double) this.getX() + dx,
-                        (double) this.getY() + dy,
-                        (double) this.getZ() + dz,
-                        (double) this.getW() + dw
-                );
+    @Override
+    public BlockPos4 getZeroInstance() {
+        return ORIGIN;
     }
 
-    public BlockPos4 add(int dx, int dy, int dz, int dw) {
-        return dx == 0 && dy == 0 && dz == 0 && dw == 0 ? this:
-                new BlockPos4(
-                        this.getX() + dx,
-                        this.getY() + dy,
-                        this.getZ() + dz,
-                        this.getW() + dw
-                );
+    @Override
+    public BlockPos4 self() {
+        return this;
     }
 
-    public BlockPos4 add(Vec4i vec4i) {
-        return this.add(
-                vec4i.getX(),
-                vec4i.getY(),
-                vec4i.getZ(),
-                vec4i.getW()
-        );
-    }
-
-    public BlockPos4 subtract(Vec4i vec4i) {
-        return this.add(
-                -vec4i.getX(),
-                -vec4i.getY(),
-                -vec4i.getZ(),
-                -vec4i.getW()
-        );
-    }
-
-    public BlockPos4 multiply(int i) {
-        if (i == 1) {
-            return this;
-        } else {
-            return i == 0 ? ORIGIN : new BlockPos4(
-                    this.getX() * i,
-                    this.getY() * i,
-                    this.getZ() * i,
-                    this.getW() * i
-            );
-        }
-    }
-
-    public BlockPos4 up() {
-        return this.offset(Direction4.UP);
-    }
-
-    public BlockPos4 up(int distance) {
-        return this.offset(Direction4.UP, distance);
-    }
-
-    public BlockPos4 down() {
-        return this.offset(Direction4.DOWN);
-    }
-
-    public BlockPos4 down(int i) {
-        return this.offset(Direction4.DOWN, i);
-    }
-
-    public BlockPos4 north() {
-        return this.offset(Direction4.NORTH);
-    }
-
-    public BlockPos4 north(int distance) {
-        return this.offset(Direction4.NORTH, distance);
-    }
-
-    public BlockPos4 south() {
-        return this.offset(Direction4.SOUTH);
-    }
-
-    public BlockPos4 south(int distance) {
-        return this.offset(Direction4.SOUTH, distance);
-    }
-
-    public BlockPos4 west() {
-        return this.offset(Direction4.WEST);
-    }
-
-    public BlockPos4 west(int distance) {
-        return this.offset(Direction4.WEST, distance);
-    }
-
-    public BlockPos4 east() {
-        return this.offset(Direction4.EAST);
-    }
-
-    public BlockPos4 east(int distance) {
-        return this.offset(Direction4.EAST, distance);
-    }
-
-    public BlockPos4 kata() {
-        return this.offset(Direction4.KATA);
-    }
-
-    public BlockPos4 kata(int distance) {
-        return this.offset(Direction4.KATA, distance);
-    }
-
-    public BlockPos4 ana() {
-        return this.offset(Direction4.ANA);
-    }
-
-    public BlockPos4 ana(int distance) {
-        return this.offset(Direction4.ANA, distance);
-    }
-
-    public BlockPos4 offset(Direction4 Direction4) {
-        return new BlockPos4(
-                this.getX() + Direction4.getOffsetX(),
-                this.getY() + Direction4.getOffsetY(),
-                this.getZ() + Direction4.getOffsetZ(),
-                this.getW() + Direction4.getOffsetW()
-        );
-    }
-
-    public BlockPos4 offset(Direction4 Direction4, int i) {
-        return i == 0 ? this : new BlockPos4(
-                this.getX() + Direction4.getOffsetX() * i,
-                this.getY() + Direction4.getOffsetY() * i,
-                this.getZ() + Direction4.getOffsetZ() * i,
-                this.getW() + Direction4.getOffsetW() * i);
-    }
-
-    public BlockPos4 offset(Axis4 axis, int i) {
-        if (i == 0) {
-            return this;
-        } else {
-            int j = axis == Axis4.X ? i : 0;
-            int k = axis == Axis4.Y ? i : 0;
-            int l = axis == Axis4.Z ? i : 0;
-            int m = axis == Axis4.W ? i : 0;
-            return new BlockPos4(this.getX() + j, this.getY() + k, this.getZ() + l, this.getZ() + m);
-        }
-    }
     static {
         ORIGIN = new BlockPos4(0, 0, 0, 0);
     }

--- a/src/main/java/com/gmail/inayakitorikhurram/fdmc/math/Direction4.java
+++ b/src/main/java/com/gmail/inayakitorikhurram/fdmc/math/Direction4.java
@@ -16,14 +16,14 @@ import java.util.stream.Stream;
 
 public enum Direction4 implements StringIdentifiable{
 
-    DOWN (0, 1, -1, "down",Direction.DOWN , AxisDirection.NEGATIVE, Axis4.Y, new Vec4i( 0, -1, 0,  0), DyeColor.BLUE.getColorComponents()),
-    UP   (1, 0, -1, "up"  ,Direction.UP   , AxisDirection.POSITIVE, Axis4.Y, new Vec4i( 0, 1,  0,  0), DyeColor.LIME.getColorComponents()),
-    NORTH(2, 3, 2, "north",Direction.NORTH, AxisDirection.NEGATIVE, Axis4.Z, new Vec4i( 0, 0, -1,  0), DyeColor.ORANGE.getColorComponents()),
-    SOUTH(3, 2, 0, "south",Direction.SOUTH, AxisDirection.POSITIVE, Axis4.Z, new Vec4i( 0, 0,  1,  0), DyeColor.LIGHT_BLUE.getColorComponents()),
-    WEST (4, 5, 1, "west" ,Direction.WEST , AxisDirection.NEGATIVE, Axis4.X, new Vec4i(-1, 0,  0,  0), DyeColor.CYAN.getColorComponents()),
-    EAST (5, 4, 3, "east" ,Direction.EAST , AxisDirection.POSITIVE, Axis4.X, new Vec4i( 1, 0,  0,  0), DyeColor.RED.getColorComponents()),
-    KATA (6, 7, 4, "kata" ,null  , AxisDirection.NEGATIVE, Axis4.W, new Vec4i( 0, 0,  0, -1), DyeColor.GREEN.getColorComponents()),// 94 124 22
-    ANA  (7, 6, 5, "ana"  ,null  , AxisDirection.POSITIVE, Axis4.W, new Vec4i( 0, 0,  0,  1), DyeColor.PURPLE.getColorComponents());// 127 50 184
+    DOWN (0, 1, -1, "down",Direction.DOWN , AxisDirection.NEGATIVE, Axis4.Y, Vec4i.newVec4i( 0, -1, 0,  0), DyeColor.BLUE.getColorComponents()),
+    UP   (1, 0, -1, "up"  ,Direction.UP   , AxisDirection.POSITIVE, Axis4.Y, Vec4i.newVec4i( 0, 1,  0,  0), DyeColor.LIME.getColorComponents()),
+    NORTH(2, 3, 2, "north",Direction.NORTH, AxisDirection.NEGATIVE, Axis4.Z, Vec4i.newVec4i( 0, 0, -1,  0), DyeColor.ORANGE.getColorComponents()),
+    SOUTH(3, 2, 0, "south",Direction.SOUTH, AxisDirection.POSITIVE, Axis4.Z, Vec4i.newVec4i( 0, 0,  1,  0), DyeColor.LIGHT_BLUE.getColorComponents()),
+    WEST (4, 5, 1, "west" ,Direction.WEST , AxisDirection.NEGATIVE, Axis4.X, Vec4i.newVec4i(-1, 0,  0,  0), DyeColor.CYAN.getColorComponents()),
+    EAST (5, 4, 3, "east" ,Direction.EAST , AxisDirection.POSITIVE, Axis4.X, Vec4i.newVec4i( 1, 0,  0,  0), DyeColor.RED.getColorComponents()),
+    KATA (6, 7, 4, "kata" ,null  , AxisDirection.NEGATIVE, Axis4.W, Vec4i.newVec4i( 0, 0,  0, -1), DyeColor.GREEN.getColorComponents()),// 94 124 22
+    ANA  (7, 6, 5, "ana"  ,null  , AxisDirection.POSITIVE, Axis4.W, Vec4i.newVec4i( 0, 0,  0,  1), DyeColor.PURPLE.getColorComponents());// 127 50 184
 
     private final int id;
     private final int idOpposite;
@@ -325,6 +325,13 @@ public enum Direction4 implements StringIdentifiable{
 
         public abstract double choose(double x, double y, double z, double w);
 
+        public static Axis4 fromAxis(Direction.Axis axis3){
+            return switch (axis3) {
+                case X -> X;
+                case Y -> Y;
+                case Z -> Z;
+            };
+        }
 
         static {
             VALUES = Axis4.values();

--- a/src/main/java/com/gmail/inayakitorikhurram/fdmc/math/Vec4i.java
+++ b/src/main/java/com/gmail/inayakitorikhurram/fdmc/math/Vec4i.java
@@ -7,263 +7,214 @@ package com.gmail.inayakitorikhurram.fdmc.math;
 
 import com.gmail.inayakitorikhurram.fdmc.FDMCConstants;
 import com.gmail.inayakitorikhurram.fdmc.math.Direction4.Axis4;
-import com.google.common.base.MoreObjects;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 import net.minecraft.util.Util;
+import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.Position;
 import net.minecraft.util.math.Vec3i;
 import org.jetbrains.annotations.Unmodifiable;
 
 @Unmodifiable
-public class Vec4i implements Comparable<Vec4i>, Pos3Equivalent<Vec3i> {
-    public static final Codec<Vec4i> CODEC;
-    public static final Vec4i ZERO;
-    private int x;
-    private int y;
-    private int z;
-    private int w;
+public interface Vec4i<E extends Vec3i & Vec4i<E>> {
+    Codec<Vec4i> CODEC = Codec.INT_STREAM.comapFlatMap((intStream) -> {
+        return Util.toArray(intStream, 4).map((is) -> {
+            return newVec4i(is[0], is[1], is[2], is[3]);
+        });
+    }, (Vec4i) -> {
+        return IntStream.of(Vec4i.getX(), Vec4i.getY(), Vec4i.getZ(), Vec4i.getW());
+    });
+
     private static Function<Vec4i, DataResult<Vec4i>> createRangeValidator(int maxAbsValue) {
         return (vec) -> {
             return Math.abs(vec.getX()) < maxAbsValue && Math.abs(vec.getY()) < maxAbsValue && Math.abs(vec.getZ()) < maxAbsValue && Math.abs(vec.getW()) < maxAbsValue ? DataResult.success(vec) : DataResult.error("Position out of range, expected at most " + maxAbsValue + ": " + vec);
         };
     }
 
-    public static Codec<Vec4i> createOffsetCodec(int maxAbsValue) {
+    static Codec<Vec4i> createOffsetCodec(int maxAbsValue) {
         return CODEC.flatXmap(createRangeValidator(maxAbsValue), createRangeValidator(maxAbsValue));
     }
 
-    public Vec4i(int x, int y, int z, int w) {
-        this.x = x;
-        this.y = y;
-        this.z = z;
-        this.w = w;
+    static Vec4iImpl newVec4i(int x, int y, int z, int w) {
+        return new Vec4iImpl(x, y, z, w);
     }
 
-    public Vec4i(double x, double y, double z, double w) {
-        this(MathHelper.floor(x), MathHelper.floor(y), MathHelper.floor(z), MathHelper.floor(w));
+    static Vec4iImpl newVec4i(double x, double y, double z, double w) {
+        return newVec4i(MathHelper.floor(x), MathHelper.floor(y), MathHelper.floor(z), MathHelper.floor(w));
     }
 
-    public Vec4i(Vec3i pos3) {
-        this(pos3.getX(), pos3.getY(), pos3.getZ());
+    static Vec4iImpl from3i(int x, int y, int z) {
+        int w = (int)(Math.floor(0.5 + (x + 0d)/FDMCConstants.STEP_DISTANCE));
+        x = x - w * FDMCConstants.STEP_DISTANCE;
+
+        return newVec4i(x, y, z, w);
     }
 
-    public Vec4i(int x, int y, int z) {
-        this.w = (int)(Math.floor(0.5 + (x + 0d)/FDMCConstants.STEP_DISTANCE));
-        this.x = x - w * FDMCConstants.STEP_DISTANCE;
-        this.y = y;
-        this.z = z;
+    static Vec4i<?> fromVec3i(Vec3i vec3i) {
+        if (vec3i instanceof Vec4i<?>) {
+            return (Vec4i<?>) vec3i;
+        }
+        return from3i(vec3i.getX(), vec3i.getY(), vec3i.getZ());
     }
 
-    @Override
-    public Vec3i toPos3() {
-        int x = this.x + FDMCConstants.STEP_DISTANCE * this.w;
-        int y = this.y;
-        int z = this.z;
+    E newInstance(int x, int y, int z, int w);
+
+    default E newInstance(double x, double y, double z, double w) {
+        return newInstance(MathHelper.floor(x), MathHelper.floor(y), MathHelper.floor(z), MathHelper.floor(w));
+    }
+
+    default Vec3i toPos3() {
+        int x = getX() + FDMCConstants.STEP_DISTANCE * getW();
+        int y = getY();
+        int z = getZ();
         return new Vec3i(x, y, z);
     }
 
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        } else if (!(o instanceof Vec4i)) {
-            return false;
-        } else {
-            Vec4i vec4i = (Vec4i)o;
-            if (this.getX() != vec4i.getX()) {
-                return false;
-            } else if (this.getY() != vec4i.getY()) {
-                return false;
-            } else if (this.getZ() != vec4i.getZ()){
-                return false;
-            } else{
-                return this.getW() != vec4i.getW();
-            }
-        }
+    // inherit from Vec3i
+    int getX();
+    // inherit from Vec3i
+    int getY();
+    // inherit from Vec3i
+    int getZ();
+
+    int getW();
+
+    E getZeroInstance();
+
+    E self();
+
+    default E add4(double x, double y, double z, double w) {
+        return x == 0.0 && y == 0.0 && z == 0.0 && w == 0.0? (E) this : newInstance((double)this.getX() + x, (double)this.getY() + y, (double)this.getZ() + z, (double)this.getW() + w);
     }
 
-    public int hashCode() {
-        return this.getX() + (this.getY() + (this.getZ() + this.getW() * 31) * 31) * 31;
+    default E add4(int x, int y, int z, int w) {
+        return x == 0 && y == 0 && z == 0 && w == 0 ? (E) this : newInstance(this.getX() + x, this.getY() + y, this.getZ() + z, this.getW() + w);
     }
 
-    public int compareTo(Vec4i vec4i) {
-        if(this.getW() != vec4i.getW()) {
-            return this.getW() - vec4i.getW();
-        } else if(this.getY() != vec4i.getY()) {
-            return this.getY() - vec4i.getY();
-        } else if(this.getZ() != vec4i.getZ()) {
-            return this.getZ() - vec4i.getZ();
-        } else {
-            return this.getX() - vec4i.getX();
-        }
+    default E add4(Vec4i<?> vec) {
+        return this.add4(vec.getX(), vec.getY(), vec.getZ(), vec.getW());
     }
 
-    public int getX() {
-        return this.x;
+    default E subtract4(Vec4i vec) {
+        return this.add4(-vec.getX(), -vec.getY(), -vec.getZ(), -vec.getW());
     }
 
-    public int getY() {
-        return this.y;
-    }
-
-    public int getZ() {
-        return this.z;
-    }
-    public int getW() {
-        return this.w;
-    }
-
-    protected Vec4i setX(int x) {
-        this.x = x;
-        return this;
-    }
-
-    protected Vec4i setY(int y) {
-        this.y = y;
-        return this;
-    }
-
-    protected Vec4i setZ(int z) {
-        this.z = z;
-        return this;
-    }
-
-    protected Vec4i setW(int w) {
-        this.w = w;
-        return this;
-    }
-
-    public Vec4i add(double x, double y, double z, double w) {
-        return x == 0.0 && y == 0.0 && z == 0.0 ? this : new Vec4i((double)this.getX() + x, (double)this.getY() + y, (double)this.getZ() + z, (double)this.getW() + w);
-    }
-
-    public Vec4i add(int x, int y, int z, int w) {
-        return x == 0 && y == 0 && z == 0 ? this : new Vec4i(this.getX() + x, this.getY() + y, this.getZ() + z, this.getW() + w);
-    }
-
-    public Vec4i add(Vec4i vec) {
-        return this.add(vec.getX(), vec.getY(), vec.getZ(), vec.getW());
-    }
-
-    public Vec4i subtract(Vec4i vec) {
-        return this.add(-vec.getX(), -vec.getY(), -vec.getZ(), -vec.getW());
-    }
-
-    public Vec4i multiply(int scale) {
+    default E multiply4(int scale) {
         if (scale == 1) {
-            return this;
+            return ((E) this); // if this errors then someone is implementing their Vec4i subclass in the wrong way.
         } else {
-            return scale == 0 ? ZERO : new Vec4i(this.getX() * scale, this.getY() * scale, this.getZ() * scale, this.getW() * scale);
+            return scale == 0 ? getZeroInstance() : newInstance(this.getX() * scale, this.getY() * scale, this.getZ() * scale, this.getW() * scale);
         }
     }
 
-    public Vec4i up() {
-        return this.up(1);
+    default E up4() {
+        return this.up4(1);
     }
 
-    public Vec4i up(int distance) {
-        return this.offset(Direction4.UP, distance);
+    default E up4(int distance) {
+        return this.offset4(Direction4.UP, distance);
     }
 
-    public Vec4i down() {
-        return this.down(1);
+    default E down4() {
+        return this.down4(1);
     }
 
-    public Vec4i down(int distance) {
-        return this.offset(Direction4.DOWN, distance);
+    default E down4(int distance) {
+        return this.offset4(Direction4.DOWN, distance);
     }
 
-    public Vec4i north() {
-        return this.north(1);
+    default E north4() {
+        return this.north4(1);
     }
 
-    public Vec4i north(int distance) {
-        return this.offset(Direction4.NORTH, distance);
+    default E north4(int distance) {
+        return this.offset4(Direction4.NORTH, distance);
     }
 
-    public Vec4i south() {
-        return this.south(1);
+    default E south4() {
+        return this.south4(1);
     }
 
-    public Vec4i south(int distance) {
-        return this.offset(Direction4.SOUTH, distance);
+    default E south4(int distance) {
+        return this.offset4(Direction4.SOUTH, distance);
     }
 
-    public Vec4i west() {
-        return this.west(1);
+    default E west4() {
+        return this.west4(1);
     }
 
-    public Vec4i west(int distance) {
-        return this.offset(Direction4.WEST, distance);
+    default E west4(int distance) {
+        return this.offset4(Direction4.WEST, distance);
     }
 
-    public Vec4i east() {
-        return this.east(1);
+    default E east4() {
+        return this.east4(1);
     }
 
-    public Vec4i east(int distance) {
-        return this.offset(Direction4.EAST, distance);
+    default E east4(int distance) {
+        return this.offset4(Direction4.EAST, distance);
     }
 
-    public Vec4i kata() {
-        return this.kata(1);
+    default E kata4() {
+        return this.kata4(1);
     }
 
-    public Vec4i kata(int distance) {
-        return this.offset(Direction4.KATA, distance);
+    default E kata4(int distance) {
+        return this.offset4(Direction4.KATA, distance);
     }
 
-    public Vec4i ana() {
-        return this.ana(1);
+    default E ana4() {
+        return this.ana4(1);
     }
 
-    public Vec4i ana(int distance) {
-        return this.offset(Direction4.ANA, distance);
+    default E ana4(int distance) {
+        return this.offset4(Direction4.ANA, distance);
     }
 
-    public Vec4i offset(Direction4 Direction4) {
-        return this.offset((Direction4)Direction4, 1);
+    default E offset4(Direction4 Direction4) {
+        return this.offset4((Direction4)Direction4, 1);
     }
 
-    public Vec4i offset(Direction4 Direction4, int distance) {
-        return distance == 0 ? this : new Vec4i(
+    default E offset4(Direction4 Direction4, int distance) {
+        return distance == 0 ? ((E) this) : newInstance(
                 this.getX() + Direction4.getOffsetX() * distance,
                 this.getY() + Direction4.getOffsetY() * distance,
                 this.getZ() + Direction4.getOffsetZ() * distance,
                 this.getW() + Direction4.getOffsetW() * distance);
     }
 
-    public Vec4i offset(Axis4 axis, int distance) {
+    default E offset4(Axis4 axis, int distance) {
         if (distance == 0) {
-            return this;
+            return ((E) this); // if this errors then someone is implementing their Vec4i subclass in the wrong way.
         } else {
             int i = axis == Axis4.X ? distance : 0;
             int j = axis == Axis4.Y ? distance : 0;
             int k = axis == Axis4.Z ? distance : 0;
             int l = axis == Axis4.W ? distance : 0;
-            return new Vec4i(this.getX() + i, this.getY() + j, this.getZ() + k, this.getW() + l);
+            return newInstance(this.getX() + i, this.getY() + j, this.getZ() + k, this.getW() + l);
         }
     }
 
-    public boolean isWithinDistance(Vec4i vec, double distance) {
-        return this.getSquaredDistance(vec) < MathHelper.square(distance);
+    default boolean isWithinDistance4(Vec4i vec4i, double distance) {
+        return this.getSquaredDistance4(vec4i) < MathHelper.square(distance);
     }
 
-    public boolean isWithinDistance(Position4 pos, double distance) {
-        return this.getSquaredDistance(pos) < MathHelper.square(distance);
+    default boolean isWithinDistance4(Position4 pos, double distance) {
+        return this.getSquaredDistance4(pos) < MathHelper.square(distance);
     }
 
-    public double getSquaredDistance(Vec4i vec) {
-        return this.getSquaredDistance((double)vec.getX(), (double)vec.getY(), (double)vec.getZ(), (double)vec.getW());
+    default double getSquaredDistance4(Vec4i vec4i) {
+        return this.getSquaredDistance4(vec4i.getX(), vec4i.getY(), vec4i.getZ(), vec4i.getW());
     }
 
-    public double getSquaredDistance(Position4<Double> pos) {
-        return this.getSquaredDistanceFromCenter(pos.getX(), pos.getY(), pos.getZ(), pos.getW());
+    default double getSquaredDistance4(Position4<Double> pos) {
+        return this.getSquaredDistanceFromCenter4(pos.getX(), pos.getY(), pos.getZ(), pos.getW());
     }
 
-    public double getSquaredDistanceFromCenter(double x, double y, double z, double w) {
+    default double getSquaredDistanceFromCenter4(double x, double y, double z, double w) {
         double dx = (double)this.getX() + 0.5 - x;
         double dy = (double)this.getY() + 0.5 - y;
         double dz = (double)this.getZ() + 0.5 - z;
@@ -271,7 +222,7 @@ public class Vec4i implements Comparable<Vec4i>, Pos3Equivalent<Vec3i> {
         return dx * dx + dy * dy + dz * dz + dw * dw;
     }
 
-    public double getSquaredDistance(double x, double y, double z, double w) {
+    default double getSquaredDistance4(double x, double y, double z, double w) {
         double dx = (double)this.getX() - x;
         double dy = (double)this.getY() - y;
         double dz = (double)this.getZ() - z;
@@ -279,7 +230,7 @@ public class Vec4i implements Comparable<Vec4i>, Pos3Equivalent<Vec3i> {
         return dx * dx + dy * dy + dz * dz + dw * dw;
     }
 
-    public int getManhattanDistance(Vec4i vec) {
+    default int getManhattanDistance4(Vec4i vec) {
         float dx = (float)Math.abs(vec.getX() - this.getX());
         float dy = (float)Math.abs(vec.getY() - this.getY());
         float dz = (float)Math.abs(vec.getZ() - this.getZ());
@@ -287,32 +238,67 @@ public class Vec4i implements Comparable<Vec4i>, Pos3Equivalent<Vec3i> {
         return (int)(dx + dy + dz + dw);
     }
 
-    public int getComponentAlongAxis(Direction4.Axis4 Axis4) {
-        return Axis4.choose(this.x, this.y, this.z, this.w);
+    default int getComponentAlongAxis4(Direction4.Axis4 Axis4) {
+        return Axis4.choose(this.getX(), this.getY(), this.getZ(), this.getW());
     }
 
-    public String toString() {
-        return MoreObjects.toStringHelper(this)
-                .add("x", this.getX())
-                .add("y", this.getY())
-                .add("z", this.getZ())
-                .add("w", this.getW())
-                .toString();
-    }
-
-    public String toShortString() {
-        int var10000 = this.getX();
-        return "" + var10000 + ", " + this.getY() + ", " + this.getZ() + ", " + this.getW();
-    }
-
-    static {
-        CODEC = Codec.INT_STREAM.comapFlatMap((intStream) -> {
-            return Util.toArray(intStream, 4).map((is) -> {
-                return new Vec4i(is[0], is[1], is[2], is[3]);
-            });
-        }, (Vec4i) -> {
-            return IntStream.of(new int[]{Vec4i.getX(), Vec4i.getY(), Vec4i.getZ(), Vec4i.getW()});
-        });
-        ZERO = new Vec4i(0, 0, 0, 0);
-    }
+    // the following ensure that Vec3i methods are exposed
+    // inherited from Vec3i
+    Vec3i add(double x, double y, double z);
+    // inherited from Vec3i
+    Vec3i add(int x, int y, int z);
+    // inherited from Vec3i
+    Vec3i add(Vec3i vec);
+    // inherited from Vec3i
+    Vec3i subtract(Vec3i vec);
+    // inherited from Vec3i
+    Vec3i multiply(int scale);
+    // inherited from Vec3i
+    Vec3i up();
+    // inherited from Vec3i
+    Vec3i up(int distance);
+    // inherited from Vec3i
+    Vec3i down();
+    // inherited from Vec3i
+    Vec3i down(int distance);
+    // inherited from Vec3i
+    Vec3i north();
+    // inherited from Vec3i
+    Vec3i north(int distance);
+    // inherited from Vec3i
+    Vec3i south();
+    // inherited from Vec3i
+    Vec3i south(int distance);
+    // inherited from Vec3i
+    Vec3i west();
+    // inherited from Vec3i
+    Vec3i west(int distance);
+    // inherited from Vec3i
+    Vec3i east();
+    // inherited from Vec3i
+    Vec3i east(int distance);
+    // inherited from Vec3i
+    Vec3i offset(Direction direction);
+    // inherited from Vec3i
+    Vec3i offset(Direction direction, int distance);
+    // inherited from Vec3i
+    Vec3i offset(Direction.Axis axis, int distance);
+    // inherited from Vec3i
+    Vec3i crossProduct(Vec3i vec);
+    // inherited from Vec3i
+    boolean isWithinDistance(Vec3i vec, double distance);
+    // inherited from Vec3i
+    boolean isWithinDistance(Position pos, double distance);
+    // inherited from Vec3i
+    double getSquaredDistance(Vec3i vec);
+    // inherited from Vec3i
+    double getSquaredDistance(Position pos);
+    // inherited from Vec3i
+    double getSquaredDistanceFromCenter(double x, double y, double z);
+    // inherited from Vec3i
+    double getSquaredDistance(double x, double y, double z);
+    // inherited from Vec3i
+    int getManhattanDistance(Vec3i vec);
+    // inherited from Vec3i
+    int getComponentAlongAxis(Direction.Axis axis);
 }

--- a/src/main/java/com/gmail/inayakitorikhurram/fdmc/math/Vec4iImpl.java
+++ b/src/main/java/com/gmail/inayakitorikhurram/fdmc/math/Vec4iImpl.java
@@ -1,0 +1,152 @@
+package com.gmail.inayakitorikhurram.fdmc.math;
+
+import com.google.common.base.MoreObjects;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.Vec3i;
+
+public class Vec4iImpl extends Vec3i implements Vec4i<Vec4iImpl> {
+    private int w;
+
+    protected Vec4iImpl(int x, int y, int z, int w) {
+        super(x, y, z);
+        this.w = w;
+    }
+
+    @Override
+    public Vec4iImpl newInstance(int x, int y, int z, int w) {
+        return new Vec4iImpl(x, y, z, w);
+    }
+
+    @Override
+    public int getW() {
+        return w;
+    }
+
+    @Override
+    public Vec4iImpl getZeroInstance() {
+        return null;
+    }
+
+    @Override
+    public Vec4iImpl self() {
+        return this;
+    }
+
+
+    @Override
+    public Vec3i add(double x, double y, double z) {
+        return add4(x, y, z, 0.0);
+    }
+
+    @Override
+    public Vec3i add(int x, int y, int z) {
+        return  add4(x, y, z, 0);
+    }
+
+    @Override
+    public Vec3i multiply(int scale) {
+        return multiply4(scale);
+    }
+
+    @Override
+    public Vec3i offset(Direction direction, int distance) {
+        return offset4(Direction4.fromDirection3(direction), distance);
+    }
+
+    @Override
+    public Vec3i offset(Direction.Axis axis, int distance) {
+        return offset4(Direction4.Axis4.fromAxis(axis), distance);
+    }
+
+    @Override
+    public boolean isWithinDistance(Vec3i vec, double distance) {
+        if (vec instanceof Vec4i<?>) {
+            return isWithinDistance4((Vec4i<?>) vec, distance);
+        }
+        return super.isWithinDistance(vec, distance);
+    }
+
+    /* //TODO: Make Position4 extend Position
+    @Override
+    public boolean isWithinDistance(Position pos, double distance) {
+        if (vec instanceof Position4) {
+            return isWithinDistance4((Position4) pos, distance);
+        }
+        return super.isWithinDistance(pos, distance);
+    }
+     */
+
+    @Override
+    public double getSquaredDistance(Vec3i vec) {
+        if (vec instanceof Vec4i<?>) {
+            return getSquaredDistance4((Vec4i<?>) vec);
+        }
+        return super.getSquaredDistance(vec);
+    }
+
+    /* //TODO: Make Position4 extend Position
+    @Override
+    public double getSquaredDistance(Position pos) {
+        if (pos instanceof Position4) {
+            return getSquaredDistance4((Position4) pos);
+        }
+        return super.getSquaredDistance(pos);
+    }
+     */
+
+    @Override
+    public int getManhattanDistance(Vec3i vec) {
+        if (vec instanceof Vec4i<?>) {
+            return getManhattanDistance4((Vec4i<?>) vec);
+        }
+        return super.getManhattanDistance(vec);
+    }
+
+    @Override
+    public int compareTo(Vec3i vec3i) {
+        if(vec3i instanceof Vec4i<?> && this.getW() != ((Vec4i<?>) vec3i).getW()) {
+            return this.getW() - ((Vec4i<?>) vec3i).getW();
+        } else if(this.getY() != vec3i.getY()) {
+            return this.getY() - vec3i.getY();
+        } else if(this.getZ() != vec3i.getZ()) {
+            return this.getZ() - vec3i.getZ();
+        } else {
+            return this.getX() - vec3i.getX();
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (!(o instanceof Vec4i)) {
+            return false;
+        } else {
+            Vec4i<?> vec4i = (Vec4i<?>)o;
+            return this.getX() == vec4i.getX()
+                    && this.getY() == vec4i.getY()
+                    && this.getZ() == vec4i.getZ()
+                    && this.getW() == vec4i.getW();
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return this.getX() + (this.getY() + (this.getZ() + this.getW() * 31) * 31) * 31;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("x", this.getX())
+                .add("y", this.getY())
+                .add("z", this.getZ())
+                .add("w", this.getW())
+                .toString();
+    }
+
+    public String toShortString() {
+        int var10000 = this.getX();
+        return "" + var10000 + ", " + this.getY() + ", " + this.getZ() + ", " + this.getW();
+    }
+}


### PR DESCRIPTION
If you have an instance of `Vec4i<?>` and want to use it as a `Vec3i` use `Vec4i#self`.