### PR TITLE
BlockPos4.Mutable4

### DIFF
--- a/src/main/java/com/gmail/inayakitorikhurram/fdmc/math/BlockPos4.java
+++ b/src/main/java/com/gmail/inayakitorikhurram/fdmc/math/BlockPos4.java
@@ -1,80 +1,172 @@
 package com.gmail.inayakitorikhurram.fdmc.math;
 
 import com.gmail.inayakitorikhurram.fdmc.FDMCConstants;
+import net.minecraft.util.BlockRotation;
 import net.minecraft.util.math.*;
-import org.jetbrains.annotations.Unmodifiable;
 
-@Unmodifiable
-public class BlockPos4 extends BlockPos implements Vec4i<BlockPos4> {
-    public static final BlockPos4 ORIGIN;
-    private int w;
+public interface BlockPos4<E extends BlockPos & BlockPos4<E, T>, T extends BlockPos> extends Vec4i<E, T> {
+    static BlockPos4<?, ?> newBlockPos4(int x, int y, int z, int w) {
+        return new BlockPos4Impl(x, y, z, w);
+    }
 
-    //util for doing some calculations before super constructor call
-    private static int convertX(Vec3i vec3i) {
-        int x = vec3i.getX();
-        if (vec3i instanceof Vec4i<?>) {
-            return x;
-        }
+    static BlockPos4<?, ?> newBlockPos4(double x, double y, double z, double w) {
+        return newBlockPos4(MathHelper.floor(x), MathHelper.floor(y), MathHelper.floor(z), MathHelper.floor(w));
+    }
+
+    static BlockPos4<?, ?> from3i(int x, int y, int z) {
         int w = (int)(Math.floor(0.5 + (x + 0d)/ FDMCConstants.STEP_DISTANCE));
-        return x - w * FDMCConstants.STEP_DISTANCE;
+        x = x - w * FDMCConstants.STEP_DISTANCE;
+
+        return newBlockPos4(x, y, z, w);
     }
 
-    public BlockPos4(int x, int y, int z, int w) {
-        super(x, y, z);
-        this.w = w;
-    }
-
-    public BlockPos4(double x, double y, double z, double w) {
-        this(MathHelper.floor(x), MathHelper.floor(y), MathHelper.floor(z), MathHelper.floor(w));
-    }
-
-    public BlockPos4(Vec4d pos) {
-        this(pos.x, pos.y, pos.z, pos.w);
-    }
-
-    public BlockPos4(Position4<Integer> pos) {
-        this(pos.getX(), pos.getY(), pos.getZ(), pos.getW());
-    }
-
-    public BlockPos4(Vec4i<?> pos) {
-        this(pos.getX(), pos.getY(), pos.getZ(), pos.getW());
-    }
-
-    public BlockPos4(Vec3i vec3i) {
-        super(convertX(vec3i), vec3i.getY(), vec3i.getZ());
-        if (vec3i instanceof Vec4i<?>) {
-            this.w = ((Vec4i<?>) vec3i).getW();
+    static BlockPos4<?, ?> fromVec3i(Vec3i vec3i) {
+        if (vec3i instanceof BlockPos4<?,?>) {
+            return (BlockPos4<?,?>) vec3i;
+        } else if (vec3i instanceof Vec4i<?, ?>) {
+            return fromVec4i((Vec4i<?, ?>) vec3i);
         } else {
-            this.w = (int)(Math.floor(0.5 + (vec3i.getX() + 0d)/ FDMCConstants.STEP_DISTANCE));
+            return from3i(vec3i.getX(), vec3i.getY(), vec3i.getZ());
         }
     }
 
-    @Override
-    public BlockPos4 newInstance(int x, int y, int z, int w) {
-        return new BlockPos4(x, y, z, w);
+    static BlockPos4<?, ?> fromVec4i(Vec4i<?, ?> vec4i) {
+        return newBlockPos4(vec4i.getX(), vec4i.getY(), vec4i.getZ(), vec4i.getW());
     }
 
-    @Override
-    public BlockPos toPos3() {
-        return new BlockPos(Vec4i.super.toPos3());
+    default BlockPos castToBlockPos() {
+        return (BlockPos) (Object) this;
     }
 
-    @Override
-    public int getW() {
-        return w;
+    // the following ensure that BlockPos methods are exposed
+    // inherited from BlockPos
+    default Vec3d toCenterPos() {
+        return castToBlockPos().toCenterPos();
+    }
+    // inherited from BlockPos
+    default BlockPos rotate(BlockRotation rotation) {
+        return castToBlockPos().rotate(rotation);
+    }
+    // inherited from BlockPos
+    default BlockPos withY(int y) {
+        return castToBlockPos().withY(y);
+    }
+    // inherited from BlockPos
+    default BlockPos toImmutable() {
+        return castToBlockPos().toImmutable();
+    }
+    // inherited from BlockPos
+    default BlockPos.Mutable mutableCopy() {
+        return castToBlockPos().mutableCopy();
     }
 
-    @Override
-    public BlockPos4 getZeroInstance() {
-        return ORIGIN;
-    }
+    interface Mutable4<E extends BlockPos & BlockPos4<E, BlockPos>> extends BlockPos4<E, BlockPos>{
+        static Mutable4<?> newMutable4() {
+            return asMutable4(new BlockPos.Mutable());
+        }
 
-    @Override
-    public BlockPos4 self() {
-        return this;
-    }
+        static Mutable4<?> newMutable4(int x, int y, int z, int w) {
+            return asMutable4(new BlockPos.Mutable(x, y, z)).setW4(w);
+        }
 
-    static {
-        ORIGIN = new BlockPos4(0, 0, 0, 0);
+        static Mutable4<?> newMutable4(double x, double y, double z, double w) {
+            return asMutable4(new BlockPos.Mutable(x, y, z)).setW4(MathHelper.floor(w));
+        }
+
+        static Mutable4<?> asMutable4(BlockPos.Mutable mutable) {
+            return (Mutable4<?>)(Object) mutable;
+        }
+
+        default BlockPos.Mutable castToBlockPosMutable() {
+            return (BlockPos.Mutable)(Object) this;
+        }
+
+        BlockPos.Mutable setW(int w);
+
+        Mutable4<?> setX4(int x);
+
+        Mutable4<?> setY4(int y);
+
+        Mutable4<?> setZ4(int z);
+
+        Mutable4<?> setW4(int w);
+
+        BlockPos.Mutable set4(int x, int y, int z, int w);
+
+        BlockPos.Mutable set4(double x, double y, double z, double w);
+
+        BlockPos.Mutable set4(Vec4i<?, ?> pos);
+        // inherited from BlockPos.Mutable //TODO: wtf does this even do?
+        //BlockPos.Mutable set4(AxisCycleDirection axis, int x, int y, int z);
+
+        BlockPos.Mutable set4(Vec4i<?, ?> pos, Direction direction);
+
+        BlockPos.Mutable set4(Vec4i<?, ?> pos, int x, int y, int z, int w);
+
+        BlockPos.Mutable set4(Vec4i<?, ?> vec1, Vec4i<?, ?> vec2);
+
+        BlockPos.Mutable move4(Direction direction);
+
+        BlockPos.Mutable move4(Direction direction, int distance);
+
+        BlockPos.Mutable move4(int dx, int dy, int dz, int dw);
+
+        BlockPos.Mutable move4(Vec4i<?, ?> vec);
+
+        BlockPos.Mutable clamp4(Direction4.Axis4 axis, int min, int max);
+
+        // the following ensure that BlockPos.Mutable methods are exposed
+        // inherited from BlockPos.Mutable
+        default BlockPos.Mutable set(int x, int y, int z) {
+            return castToBlockPosMutable().set(x, y, z);
+        }
+        // inherited from BlockPos.Mutable
+        default BlockPos.Mutable set(double x, double y, double z) {
+            return castToBlockPosMutable().set(x, y, z);
+        }
+        // inherited from BlockPos.Mutable
+        default BlockPos.Mutable set(Vec3i pos) {
+            return castToBlockPosMutable().set(pos);
+        }
+        // inherited from BlockPos.Mutable
+        default BlockPos.Mutable set(long pos) {
+            return castToBlockPosMutable().set(pos);
+        }
+        // inherited from BlockPos.Mutable
+        default BlockPos.Mutable set(AxisCycleDirection axis, int x, int y, int z) {
+            return castToBlockPosMutable().set(axis, x, y, z);
+        }
+        // inherited from BlockPos.Mutable
+        default BlockPos.Mutable set(Vec3i pos, Direction direction) {
+            return castToBlockPosMutable().set(pos, direction);
+        }
+        // inherited from BlockPos.Mutable
+        default BlockPos.Mutable set(Vec3i pos, int x, int y, int z) {
+            return castToBlockPosMutable().set(pos, x, y, z);
+        }
+        // inherited from BlockPos.Mutable
+        default BlockPos.Mutable set(Vec3i vec1, Vec3i vec2) {
+            return castToBlockPosMutable().set(vec1, vec2);
+        }
+        // inherited from BlockPos.Mutable
+        default BlockPos.Mutable move(Direction direction) {
+            return castToBlockPosMutable().move(direction);
+        }
+        // inherited from BlockPos.Mutable
+        default BlockPos.Mutable move(Direction direction, int distance) {
+            return castToBlockPosMutable().move(direction, distance);
+        }
+        // inherited from BlockPos.Mutable
+        default BlockPos.Mutable move(int dx, int dy, int dz) {
+            return castToBlockPosMutable().move(dx, dy, dz);
+        }
+        // inherited from BlockPos.Mutable
+        default BlockPos.Mutable move(Vec3i vec) {
+            return castToBlockPosMutable().move(vec);
+        }
+        // inherited from BlockPos.Mutable
+        default BlockPos.Mutable clamp(Direction.Axis axis, int min, int max) {
+            return castToBlockPosMutable().clamp(axis, min, max);
+        }
     }
 }

--- a/src/main/java/com/gmail/inayakitorikhurram/fdmc/math/BlockPos4.java
+++ b/src/main/java/com/gmail/inayakitorikhurram/fdmc/math/BlockPos4.java
@@ -38,6 +38,38 @@ public interface BlockPos4<E extends BlockPos & BlockPos4<E, T>, T extends Block
         return (BlockPos) (Object) this;
     }
 
+    default Vec4d toCenterPos4() {
+        return Vec4d.ofCenter(this);
+    }
+
+    default E rotate4(BlockRotation rotation) {
+        switch (rotation) {
+            default: {
+                return self();
+            }
+            case CLOCKWISE_90: {
+                return newInstance(-this.getZ(), this.getY(), this.getX(), this.getW());
+            }
+            case CLOCKWISE_180: {
+                return newInstance(-this.getX(), this.getY(), -this.getZ(), this.getW());
+            }
+            case COUNTERCLOCKWISE_90:
+                return newInstance(this.getZ(), this.getY(), -this.getX(), this.getW());
+        }
+    }
+
+    default E withY4(int y) {
+        return newInstance(getX(), y, getZ(), getW());
+    }
+
+    default BlockPos4<?, ?> toImmutable4() {
+        return (BlockPos4<?, ?>)(Object) toImmutable();
+    }
+
+    default BlockPos4.Mutable4<?> mutableCopy4() {
+        return (BlockPos4.Mutable4<?>)(Object) mutableCopy();
+    }
+
     // the following ensure that BlockPos methods are exposed
     // inherited from BlockPos
     default Vec3d toCenterPos() {
@@ -91,29 +123,29 @@ public interface BlockPos4<E extends BlockPos & BlockPos4<E, T>, T extends Block
 
         Mutable4<?> setW4(int w);
 
-        BlockPos.Mutable set4(int x, int y, int z, int w);
+        Mutable4<?> set4(int x, int y, int z, int w);
 
-        BlockPos.Mutable set4(double x, double y, double z, double w);
+        Mutable4<?> set4(double x, double y, double z, double w);
 
-        BlockPos.Mutable set4(Vec4i<?, ?> pos);
+        Mutable4<?> set4(Vec4i<?, ?> pos);
         // inherited from BlockPos.Mutable //TODO: wtf does this even do?
         //BlockPos.Mutable set4(AxisCycleDirection axis, int x, int y, int z);
 
-        BlockPos.Mutable set4(Vec4i<?, ?> pos, Direction direction);
+        Mutable4<?> set4(Vec4i<?, ?> pos, Direction4 direction);
 
-        BlockPos.Mutable set4(Vec4i<?, ?> pos, int x, int y, int z, int w);
+        Mutable4<?> set4(Vec4i<?, ?> pos, int x, int y, int z, int w);
 
-        BlockPos.Mutable set4(Vec4i<?, ?> vec1, Vec4i<?, ?> vec2);
+        Mutable4<?> set4(Vec4i<?, ?> vec1, Vec4i<?, ?> vec2);
 
-        BlockPos.Mutable move4(Direction direction);
+        Mutable4<?> move4(Direction4 direction);
 
-        BlockPos.Mutable move4(Direction direction, int distance);
+        Mutable4<?> move4(Direction4 direction, int distance);
 
-        BlockPos.Mutable move4(int dx, int dy, int dz, int dw);
+        Mutable4<?> move4(int dx, int dy, int dz, int dw);
 
-        BlockPos.Mutable move4(Vec4i<?, ?> vec);
+        Mutable4<?> move4(Vec4i<?, ?> vec);
 
-        BlockPos.Mutable clamp4(Direction4.Axis4 axis, int min, int max);
+        Mutable4<?> clamp4(Direction4.Axis4 axis, int min, int max);
 
         // the following ensure that BlockPos.Mutable methods are exposed
         // inherited from BlockPos.Mutable

--- a/src/main/java/com/gmail/inayakitorikhurram/fdmc/math/BlockPos4Impl.java
+++ b/src/main/java/com/gmail/inayakitorikhurram/fdmc/math/BlockPos4Impl.java
@@ -1,0 +1,80 @@
+package com.gmail.inayakitorikhurram.fdmc.math;
+
+import com.gmail.inayakitorikhurram.fdmc.FDMCConstants;
+import net.minecraft.util.math.*;
+import org.jetbrains.annotations.Unmodifiable;
+
+@Unmodifiable
+public class BlockPos4Impl extends BlockPos implements BlockPos4<BlockPos4Impl, BlockPos> {
+    public static final BlockPos4Impl ORIGIN;
+    private int w;
+
+    // util for doing some calculations before super constructor call
+    private static int convertX(Vec3i vec3i) {
+        int x = vec3i.getX();
+        if (vec3i instanceof Vec4i<?, ?>) {
+            return x;
+        }
+        int w = (int)(Math.floor(0.5 + (x + 0d)/ FDMCConstants.STEP_DISTANCE));
+        return x - w * FDMCConstants.STEP_DISTANCE;
+    }
+
+    protected BlockPos4Impl(int x, int y, int z, int w) {
+        super(x, y, z);
+        this.w = w;
+    }
+
+    protected BlockPos4Impl(double x, double y, double z, double w) {
+        this(MathHelper.floor(x), MathHelper.floor(y), MathHelper.floor(z), MathHelper.floor(w));
+    }
+
+    protected BlockPos4Impl(Vec4d pos) {
+        this(pos.x, pos.y, pos.z, pos.w);
+    }
+
+    protected BlockPos4Impl(Position4<Integer> pos) {
+        this(pos.getX(), pos.getY(), pos.getZ(), pos.getW());
+    }
+
+    protected BlockPos4Impl(Vec4i<?, ?> pos) {
+        this(pos.getX(), pos.getY(), pos.getZ(), pos.getW());
+    }
+
+    protected BlockPos4Impl(Vec3i vec3i) {
+        super(convertX(vec3i), vec3i.getY(), vec3i.getZ());
+        if (vec3i instanceof Vec4i<?, ?>) {
+            this.w = ((Vec4i<?, ?>) vec3i).getW();
+        } else {
+            this.w = (int)(Math.floor(0.5 + (vec3i.getX() + 0d)/ FDMCConstants.STEP_DISTANCE));
+        }
+    }
+
+    @Override
+    public BlockPos4Impl newInstance(int x, int y, int z, int w) {
+        return new BlockPos4Impl(x, y, z, w);
+    }
+
+    @Override
+    public BlockPos newSuperInstance(int x, int y, int z) {
+        return new BlockPos(x, y, z);
+    }
+
+    @Override
+    public int getW() {
+        return w;
+    }
+
+    @Override
+    public BlockPos4Impl getZeroInstance() {
+        return ORIGIN;
+    }
+
+    @Override
+    public BlockPos4Impl self() {
+        return this;
+    }
+
+    static {
+        ORIGIN = new BlockPos4Impl(0, 0, 0, 0);
+    }
+}

--- a/src/main/java/com/gmail/inayakitorikhurram/fdmc/math/ChunkPos4.java
+++ b/src/main/java/com/gmail/inayakitorikhurram/fdmc/math/ChunkPos4.java
@@ -17,7 +17,7 @@ public class ChunkPos4 implements Pos3Equivalent<ChunkPos> {
         this.w = w;
     }
 
-    public ChunkPos4(BlockPos4 pos) {
+    public ChunkPos4(BlockPos4Impl pos) {
         this.x = ChunkSectionPos.getSectionCoord(pos.getX());
         this.z = ChunkSectionPos.getSectionCoord(pos.getZ());
         this.w = pos.getW();
@@ -96,8 +96,8 @@ public class ChunkPos4 implements Pos3Equivalent<ChunkPos> {
         return this.z & 31;
     }
 
-    public BlockPos4 getBlockPos(int offsetX, int y, int offsetZ) {
-        return new BlockPos4(this.getOffsetX(offsetX), y, this.getOffsetZ(offsetZ), this.w);
+    public BlockPos4Impl getBlockPos(int offsetX, int y, int offsetZ) {
+        return new BlockPos4Impl(this.getOffsetX(offsetX), y, this.getOffsetZ(offsetZ), this.w);
     }
 
     public int getOffsetX(int offset) {
@@ -116,8 +116,8 @@ public class ChunkPos4 implements Pos3Equivalent<ChunkPos> {
         return "[" + this.x + ", " + this.z + ", " + this.w + "]";
     }
 
-    public BlockPos4 getStartPos() {
-        return new BlockPos4(this.getStartX(), 0, this.getStartZ(), this.w);
+    public BlockPos4Impl getStartPos() {
+        return new BlockPos4Impl(this.getStartX(), 0, this.getStartZ(), this.w);
     }
 
     public int getChebyshevDistance(ChunkPos4 pos) {

--- a/src/main/java/com/gmail/inayakitorikhurram/fdmc/math/Vec4i.java
+++ b/src/main/java/com/gmail/inayakitorikhurram/fdmc/math/Vec4i.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.Unmodifiable;
 
 @Unmodifiable
 @SuppressWarnings("rawtypes")//all of there are unparameterised but it shuld be fiiiine
-public interface Vec4i<E extends Vec3i & Vec4i<E>> {
+public interface Vec4i<E extends Vec3i & Vec4i<E, T>, T extends Vec3i> {
     Codec<Vec4i> CODEC = Codec.INT_STREAM.comapFlatMap((intStream) -> {
         return Util.toArray(intStream, 4).map((is) -> {
             return newVec4i(is[0], is[1], is[2], is[3]);
@@ -54,9 +54,9 @@ public interface Vec4i<E extends Vec3i & Vec4i<E>> {
         return newVec4i(x, y, z, w);
     }
 
-    static Vec4i<?> fromVec3i(Vec3i vec3i) {
-        if (vec3i instanceof Vec4i<?>) {
-            return (Vec4i<?>) vec3i;
+    static Vec4i<?, ?> fromVec3i(Vec3i vec3i) {
+        if (vec3i instanceof Vec4i<?, ?>) {
+            return (Vec4i<?, ?>) vec3i;
         }
         return from3i(vec3i.getX(), vec3i.getY(), vec3i.getZ());
     }
@@ -67,21 +67,33 @@ public interface Vec4i<E extends Vec3i & Vec4i<E>> {
         return newInstance(MathHelper.floor(x), MathHelper.floor(y), MathHelper.floor(z), MathHelper.floor(w));
     }
 
-    default Vec3i toPos3() {
+    T newSuperInstance(int x, int y, int z);
+
+    default T toPos3() {
         int x = getX() + FDMCConstants.STEP_DISTANCE * getW();
         int y = getY();
         int z = getZ();
-        return new Vec3i(x, y, z);
+        return newSuperInstance(x, y, z);
     }
 
     // inherit from Vec3i
-    int getX();
+    default int getX() {
+        return castToVec3i().getX();
+    }
     // inherit from Vec3i
-    int getY();
+    default int getY() {
+        return castToVec3i().getY();
+    }
     // inherit from Vec3i
-    int getZ();
+    default int getZ() {
+        return castToVec3i().getZ();
+    }
 
     int getW();
+
+    default Vec3i castToVec3i() {
+        return (Vec3i)(Object) this;
+    }
 
     E getZeroInstance();
 
@@ -95,7 +107,7 @@ public interface Vec4i<E extends Vec3i & Vec4i<E>> {
         return x == 0 && y == 0 && z == 0 && w == 0 ? (E) this : newInstance(this.getX() + x, this.getY() + y, this.getZ() + z, this.getW() + w);
     }
 
-    default E add4(Vec4i<?> vec) {
+    default E add4(Vec4i<?, ?> vec) {
         return this.add4(vec.getX(), vec.getY(), vec.getZ(), vec.getW());
     }
 
@@ -245,61 +257,119 @@ public interface Vec4i<E extends Vec3i & Vec4i<E>> {
 
     // the following ensure that Vec3i methods are exposed
     // inherited from Vec3i
-    Vec3i add(double x, double y, double z);
+    default Vec3i add(double x, double y, double z) {
+        return castToVec3i().add(x, y, z);
+    }
     // inherited from Vec3i
-    Vec3i add(int x, int y, int z);
+    default Vec3i add(int x, int y, int z) {
+        return castToVec3i().add(x, y, z);
+    }
     // inherited from Vec3i
-    Vec3i add(Vec3i vec);
+    default Vec3i add(Vec3i vec) {
+        return castToVec3i().add(vec);
+    }
     // inherited from Vec3i
-    Vec3i subtract(Vec3i vec);
+    default Vec3i subtract(Vec3i vec) {
+        return castToVec3i().subtract(vec);
+    }
     // inherited from Vec3i
-    Vec3i multiply(int scale);
+    default Vec3i multiply(int scale) {
+        return castToVec3i().multiply(scale);
+    }
     // inherited from Vec3i
-    Vec3i up();
+    default Vec3i up() {
+        return castToVec3i().up();
+    }
     // inherited from Vec3i
-    Vec3i up(int distance);
+    default Vec3i up(int distance) {
+        return castToVec3i().up(distance);
+    }
     // inherited from Vec3i
-    Vec3i down();
+    default Vec3i down() {
+        return castToVec3i().down();
+    }
     // inherited from Vec3i
-    Vec3i down(int distance);
+    default Vec3i down(int distance) {
+        return castToVec3i().down(distance);
+    }
     // inherited from Vec3i
-    Vec3i north();
+    default Vec3i north() {
+        return castToVec3i().north();
+    }
     // inherited from Vec3i
-    Vec3i north(int distance);
+    default Vec3i north(int distance) {
+        return castToVec3i().north(distance);
+    }
     // inherited from Vec3i
-    Vec3i south();
+    default Vec3i south() {
+        return castToVec3i().south();
+    }
     // inherited from Vec3i
-    Vec3i south(int distance);
+    default Vec3i south(int distance) {
+        return castToVec3i().south(distance);
+    }
     // inherited from Vec3i
-    Vec3i west();
+    default Vec3i west() {
+        return castToVec3i().west();
+    }
     // inherited from Vec3i
-    Vec3i west(int distance);
+    default Vec3i west(int distance) {
+        return castToVec3i().west(distance);
+    }
     // inherited from Vec3i
-    Vec3i east();
+    default Vec3i east() {
+        return castToVec3i().east();
+    }
     // inherited from Vec3i
-    Vec3i east(int distance);
+    default Vec3i east(int distance) {
+        return castToVec3i().east(distance);
+    }
     // inherited from Vec3i
-    Vec3i offset(Direction direction);
+    default Vec3i offset(Direction direction) {
+        return castToVec3i().offset(direction);
+    }
     // inherited from Vec3i
-    Vec3i offset(Direction direction, int distance);
+    default Vec3i offset(Direction direction, int distance) {
+        return castToVec3i().offset(direction, distance);
+    }
     // inherited from Vec3i
-    Vec3i offset(Direction.Axis axis, int distance);
+    default Vec3i offset(Direction.Axis axis, int distance) {
+        return castToVec3i().offset(axis, distance);
+    }
     // inherited from Vec3i
-    Vec3i crossProduct(Vec3i vec);
+    default Vec3i crossProduct(Vec3i vec) {
+        return castToVec3i().crossProduct(vec);
+    }
     // inherited from Vec3i
-    boolean isWithinDistance(Vec3i vec, double distance);
+    default boolean isWithinDistance(Vec3i vec, double distance) {
+        return castToVec3i().isWithinDistance(vec, distance);
+    }
     // inherited from Vec3i
-    boolean isWithinDistance(Position pos, double distance);
+    default boolean isWithinDistance(Position pos, double distance) {
+        return castToVec3i().isWithinDistance(pos, distance);
+    }
     // inherited from Vec3i
-    double getSquaredDistance(Vec3i vec);
+    default double getSquaredDistance(Vec3i vec) {
+        return castToVec3i().getSquaredDistance(vec);
+    }
     // inherited from Vec3i
-    double getSquaredDistance(Position pos);
+    default double getSquaredDistance(Position pos) {
+        return castToVec3i().getSquaredDistance(pos);
+    }
     // inherited from Vec3i
-    double getSquaredDistanceFromCenter(double x, double y, double z);
+    default double getSquaredDistanceFromCenter(double x, double y, double z) {
+        return castToVec3i().getSquaredDistanceFromCenter(x, y, z);
+    }
     // inherited from Vec3i
-    double getSquaredDistance(double x, double y, double z);
+    default double getSquaredDistance(double x, double y, double z) {
+        return castToVec3i().getSquaredDistance(x, y, z);
+    }
     // inherited from Vec3i
-    int getManhattanDistance(Vec3i vec);
+    default int getManhattanDistance(Vec3i vec) {
+        return castToVec3i().getManhattanDistance(vec);
+    }
     // inherited from Vec3i
-    int getComponentAlongAxis(Direction.Axis axis);
+    default int getComponentAlongAxis(Direction.Axis axis) {
+        return castToVec3i().getComponentAlongAxis(axis);
+    }
 }

--- a/src/main/java/com/gmail/inayakitorikhurram/fdmc/math/Vec4iImpl.java
+++ b/src/main/java/com/gmail/inayakitorikhurram/fdmc/math/Vec4iImpl.java
@@ -4,8 +4,8 @@ import com.google.common.base.MoreObjects;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3i;
 
-public class Vec4iImpl extends Vec3i implements Vec4i<Vec4iImpl> {
-    private int w;
+public class Vec4iImpl extends Vec3i implements Vec4i<Vec4iImpl, Vec3i> {
+    private final int w;
 
     protected Vec4iImpl(int x, int y, int z, int w) {
         super(x, y, z);
@@ -15,6 +15,11 @@ public class Vec4iImpl extends Vec3i implements Vec4i<Vec4iImpl> {
     @Override
     public Vec4iImpl newInstance(int x, int y, int z, int w) {
         return new Vec4iImpl(x, y, z, w);
+    }
+
+    @Override
+    public Vec3i newSuperInstance(int x, int y, int z) {
+        return new Vec3i(x, y, z);
     }
 
     @Override
@@ -32,36 +37,35 @@ public class Vec4iImpl extends Vec3i implements Vec4i<Vec4iImpl> {
         return this;
     }
 
-
     @Override
-    public Vec3i add(double x, double y, double z) {
+    public Vec4iImpl add(double x, double y, double z) {
         return add4(x, y, z, 0.0);
     }
 
     @Override
-    public Vec3i add(int x, int y, int z) {
+    public Vec4iImpl add(int x, int y, int z) {
         return  add4(x, y, z, 0);
     }
 
     @Override
-    public Vec3i multiply(int scale) {
+    public Vec4iImpl multiply(int scale) {
         return multiply4(scale);
     }
 
     @Override
-    public Vec3i offset(Direction direction, int distance) {
+    public Vec4iImpl offset(Direction direction, int distance) {
         return offset4(Direction4.fromDirection3(direction), distance);
     }
 
     @Override
-    public Vec3i offset(Direction.Axis axis, int distance) {
+    public Vec4iImpl offset(Direction.Axis axis, int distance) {
         return offset4(Direction4.Axis4.fromAxis(axis), distance);
     }
 
     @Override
     public boolean isWithinDistance(Vec3i vec, double distance) {
-        if (vec instanceof Vec4i<?>) {
-            return isWithinDistance4((Vec4i<?>) vec, distance);
+        if (vec instanceof Vec4i<?, ?>) {
+            return isWithinDistance4((Vec4i<?, ?>) vec, distance);
         }
         return super.isWithinDistance(vec, distance);
     }
@@ -78,8 +82,8 @@ public class Vec4iImpl extends Vec3i implements Vec4i<Vec4iImpl> {
 
     @Override
     public double getSquaredDistance(Vec3i vec) {
-        if (vec instanceof Vec4i<?>) {
-            return getSquaredDistance4((Vec4i<?>) vec);
+        if (vec instanceof Vec4i<?, ?>) {
+            return getSquaredDistance4((Vec4i<?, ?>) vec);
         }
         return super.getSquaredDistance(vec);
     }
@@ -96,16 +100,16 @@ public class Vec4iImpl extends Vec3i implements Vec4i<Vec4iImpl> {
 
     @Override
     public int getManhattanDistance(Vec3i vec) {
-        if (vec instanceof Vec4i<?>) {
-            return getManhattanDistance4((Vec4i<?>) vec);
+        if (vec instanceof Vec4i<?, ?>) {
+            return getManhattanDistance4((Vec4i<?, ?>) vec);
         }
         return super.getManhattanDistance(vec);
     }
 
     @Override
     public int compareTo(Vec3i vec3i) {
-        if(vec3i instanceof Vec4i<?> && this.getW() != ((Vec4i<?>) vec3i).getW()) {
-            return this.getW() - ((Vec4i<?>) vec3i).getW();
+        if(vec3i instanceof Vec4i<?, ?> && this.getW() != ((Vec4i<?, ?>) vec3i).getW()) {
+            return this.getW() - ((Vec4i<?, ?>) vec3i).getW();
         } else if(this.getY() != vec3i.getY()) {
             return this.getY() - vec3i.getY();
         } else if(this.getZ() != vec3i.getZ()) {
@@ -121,13 +125,12 @@ public class Vec4iImpl extends Vec3i implements Vec4i<Vec4iImpl> {
             return true;
         } else if (!(o instanceof Vec4i)) {
             return false;
-        } else {
-            Vec4i<?> vec4i = (Vec4i<?>)o;
-            return this.getX() == vec4i.getX()
-                    && this.getY() == vec4i.getY()
-                    && this.getZ() == vec4i.getZ()
-                    && this.getW() == vec4i.getW();
         }
+        Vec4i<?, ?> vec4i = (Vec4i<?, ?>)o;
+        return this.getX() == vec4i.getX()
+                && this.getY() == vec4i.getY()
+                && this.getZ() == vec4i.getZ()
+                && this.getW() == vec4i.getW();
     }
 
     @Override

--- a/src/main/java/com/gmail/inayakitorikhurram/fdmc/mixin/DebugHudMixin.java
+++ b/src/main/java/com/gmail/inayakitorikhurram/fdmc/mixin/DebugHudMixin.java
@@ -2,7 +2,6 @@ package com.gmail.inayakitorikhurram.fdmc.mixin;
 
 import com.gmail.inayakitorikhurram.fdmc.math.BlockPos4;
 import com.gmail.inayakitorikhurram.fdmc.math.ChunkPos4;
-import com.gmail.inayakitorikhurram.fdmc.math.FDMCMath;
 import com.gmail.inayakitorikhurram.fdmc.math.Vec4d;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawableHelper;
@@ -29,7 +28,7 @@ public abstract class DebugHudMixin<E> extends DrawableHelper {
         //pos
         Entity camera = client.getCameraEntity();
         Vec4d camPos4 = new Vec4d(camera.getPos());
-        BlockPos4 blockPos4 = new BlockPos4(camera.getBlockPos());
+        BlockPos4<?, ?> blockPos4 = BlockPos4.fromVec3i(camera.getBlockPos());
         ChunkPos4 chunkPos4 = new ChunkPos4(camera.getChunkPos());
         int w = blockPos4.getW();
         list.add("4 Position: W = " + w);

--- a/src/main/java/com/gmail/inayakitorikhurram/fdmc/mixin/math/BlockPosMutableMixin.java
+++ b/src/main/java/com/gmail/inayakitorikhurram/fdmc/mixin/math/BlockPosMutableMixin.java
@@ -1,0 +1,95 @@
+package com.gmail.inayakitorikhurram.fdmc.mixin.math;
+
+import com.gmail.inayakitorikhurram.fdmc.math.BlockPos4;
+import com.gmail.inayakitorikhurram.fdmc.math.BlockPos4Impl;
+import com.gmail.inayakitorikhurram.fdmc.math.Vec4i;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.Vec3i;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+
+@Mixin(BlockPos.Mutable.class)
+public abstract class BlockPosMutableMixin extends BlockPos implements BlockPos4.Mutable4<BlockPos4Impl> {
+    private int w = 0;
+
+    public BlockPosMutableMixin(int x, int y, int z) {
+        super(x, y, z);
+    }
+
+    public int getW() {
+        return w;
+    }
+
+    public BlockPos.Mutable setW(int w) {
+       this.w = w;
+       return (BlockPos.Mutable)(Object) this;
+    }
+
+    // TODO: implement like a million methods
+
+    public BlockPos4Impl getZeroInstance() {
+        return BlockPos4Impl.ORIGIN;
+    }
+
+    public BlockPos4Impl self() {
+        return newInstance(this.getX(), this.getY(), this.getZ(), this.getW());
+    }
+
+    @Inject(method = "set(Lnet/minecraft/util/math/Vec3i;)Lnet/minecraft/util/math/BlockPos$Mutable;", at = @At("HEAD"))
+    private void setMixin(Vec3i pos, CallbackInfoReturnable<Mutable> cir) {
+        if (pos instanceof Vec4i<?, ?>) {
+            this.setW(((Vec4i<?, ?>) pos).getW());
+        }
+    }
+
+    @Inject(method = "set(Lnet/minecraft/util/math/Vec3i;Lnet/minecraft/util/math/Direction;)Lnet/minecraft/util/math/BlockPos$Mutable;", at = @At("HEAD"))
+    private void setMixin(Vec3i pos, Direction direction, CallbackInfoReturnable<Mutable> cir) {
+        // TODO: Direction4 compat
+        if (pos instanceof Vec4i<?, ?>) {
+            this.setW(((Vec4i<?, ?>) pos).getW());
+        }
+    }
+
+    @Inject(method = "set(Lnet/minecraft/util/math/Vec3i;III)Lnet/minecraft/util/math/BlockPos$Mutable;", at = @At("HEAD"))
+    private void setMixin(Vec3i pos, int x, int y, int z, CallbackInfoReturnable<Mutable> cir) {
+        if (pos instanceof Vec4i<?, ?>) {
+            this.setW(((Vec4i<?, ?>) pos).getW());
+        }
+    }
+
+    @Inject(method = "set(Lnet/minecraft/util/math/Vec3i;Lnet/minecraft/util/math/Vec3i;)Lnet/minecraft/util/math/BlockPos$Mutable;", at = @At("HEAD"))
+    private void setMixin(Vec3i vec1, Vec3i vec2, CallbackInfoReturnable<Mutable> cir) {
+        int val = 0;
+        if (vec1 instanceof Vec4i<?, ?>) {
+            val += ((Vec4i<?, ?>) vec1).getW();
+        }
+        if (vec2 instanceof Vec4i<?, ?>) {
+            val += ((Vec4i<?, ?>) vec2).getW();
+        }
+        this.setW(val);
+    }
+    /* TODO: Direction4 compat
+    @Inject(method = "move(Lnet/minecraft/util/math/Direction;I)Lnet/minecraft/util/math/BlockPos$Mutable;", at = @At("HEAD"))
+    private void moveMixin(Direction direction, int distance, CallbackInfoReturnable<Mutable> cir) {
+
+    }
+     */
+
+    @Inject(method = "move(Lnet/minecraft/util/math/Vec3i;)Lnet/minecraft/util/math/BlockPos$Mutable;", at = @At("HEAD"))
+    private void moveMixin(Vec3i vec, CallbackInfoReturnable<Mutable> cir) {
+        if (vec instanceof Vec4i<?, ?>) {
+            this.setW(this.getW() + ((Vec4i<?, ?>) vec).getW());
+        }
+    }
+
+    /* TODO Direction4.Axis4 compat
+    @Inject(method = "clamp(Lnet/minecraft/util/math/Direction$Axis;II)Lnet/minecraft/util/math/BlockPos$Mutable;", at = @At("HEAD"))
+    private void clampMixin(Direction.Axis axis, int min, int max, CallbackInfoReturnable<Mutable> cir) {
+
+    }
+     */
+}

--- a/src/main/java/com/gmail/inayakitorikhurram/fdmc/mixin/math/BlockPosMutableMixin.java
+++ b/src/main/java/com/gmail/inayakitorikhurram/fdmc/mixin/math/BlockPosMutableMixin.java
@@ -2,11 +2,14 @@ package com.gmail.inayakitorikhurram.fdmc.mixin.math;
 
 import com.gmail.inayakitorikhurram.fdmc.math.BlockPos4;
 import com.gmail.inayakitorikhurram.fdmc.math.BlockPos4Impl;
+import com.gmail.inayakitorikhurram.fdmc.math.Direction4;
 import com.gmail.inayakitorikhurram.fdmc.math.Vec4i;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3i;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
@@ -14,29 +17,119 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(BlockPos.Mutable.class)
 public abstract class BlockPosMutableMixin extends BlockPos implements BlockPos4.Mutable4<BlockPos4Impl> {
+    @Shadow public abstract Mutable setX(int i);
+
+    @Shadow public abstract Mutable setZ(int i);
+
     private int w = 0;
 
     public BlockPosMutableMixin(int x, int y, int z) {
         super(x, y, z);
     }
 
+    @Override
     public int getW() {
         return w;
     }
 
+    @Override
     public BlockPos.Mutable setW(int w) {
        this.w = w;
        return (BlockPos.Mutable)(Object) this;
     }
 
-    // TODO: implement like a million methods
-
+    @Override
     public BlockPos4Impl getZeroInstance() {
         return BlockPos4Impl.ORIGIN;
     }
 
+    @Override
     public BlockPos4Impl self() {
         return newInstance(this.getX(), this.getY(), this.getZ(), this.getW());
+    }
+
+    @Override
+    public Mutable4<?> setX4(int x) {
+        this.setX(x);
+        return this;
+    }
+
+    @Override
+    public Mutable4<?> setY4(int y) {
+        this.setY(y);
+        return this;
+    }
+
+    @Override
+    public Mutable4<?> setZ4(int z) {
+        this.setZ(z);
+        return this;
+    }
+
+    @Override
+    public Mutable4<?> setW4(int w) {
+        this.w = w;
+        return this;
+    }
+
+    @Override
+    public Mutable4<?> set4(int x, int y, int z, int w) {
+        return this.setX4(x).setY4(y).setZ4(z).setW4(w);
+    }
+
+    @Override
+    public Mutable4<?> set4(double x, double y, double z, double w) {
+        return set4(MathHelper.floor(x), MathHelper.floor(y), MathHelper.floor(z), MathHelper.floor(w));
+    }
+
+    @Override
+    public Mutable4<?> set4(Vec4i<?, ?> pos) {
+        return this.set4(pos.getX(), pos.getY(), pos.getZ(), pos.getW());
+    }
+
+    @Override
+    public Mutable4<?> set4(Vec4i<?, ?> pos, Direction4 direction) {
+        return this.set4(pos.getX() + direction.getOffsetX(), pos.getY() + direction.getOffsetY(), pos.getZ() + direction.getOffsetZ(), pos.getW() + direction.getOffsetW());
+    }
+
+    @Override
+    public Mutable4<?> set4(Vec4i<?, ?> pos, int x, int y, int z, int w) {
+        return this.set4(pos.getX() + x, pos.getY() + y, pos.getZ() + z, pos.getW() + w);
+    }
+
+    @Override
+    public Mutable4<?> set4(Vec4i<?, ?> vec1, Vec4i<?, ?> vec2) {
+        return this.set4(vec1.getX() + vec2.getX(), vec1.getY() + vec2.getY(), vec1.getZ() + vec2.getZ(), vec1.getW() + vec2.getW());
+    }
+
+    @Override
+    public Mutable4<?> move4(Direction4 direction) {
+        return this.move4(direction, 1);
+    }
+
+    @Override
+    public Mutable4<?> move4(Direction4 direction, int distance) {
+        return this.set4(this.getX() + direction.getOffsetX() * distance, this.getY() + direction.getOffsetY() * distance, this.getZ() + direction.getOffsetZ() * distance, this.getW() + direction.getOffsetW() * distance);
+    }
+
+    @Override
+    public Mutable4<?> move4(int dx, int dy, int dz, int dw) {
+        return this.set4(this.getX() + dx, this.getY() + dy, this.getZ() + dz, this.getW() + dw);
+    }
+
+    @Override
+    public Mutable4<?> move4(Vec4i<?, ?> vec) {
+        return this.move4(vec.getX(), vec.getY(), vec.getZ(), vec.getW());
+    }
+
+    @Override
+    public Mutable4<?> clamp4(Direction4.Axis4 axis, int min, int max) {
+        return switch (axis) {
+            case X -> this.setX4(MathHelper.clamp(this.getX(), min, max));
+            case Y -> this.setY4(MathHelper.clamp(this.getY(), min, max));
+            case Z -> this.setZ4(MathHelper.clamp(this.getZ(), min, max));
+            case W -> this.setW4(MathHelper.clamp(this.getW(), min, max));
+        };
     }
 
     @Inject(method = "set(Lnet/minecraft/util/math/Vec3i;)Lnet/minecraft/util/math/BlockPos$Mutable;", at = @At("HEAD"))

--- a/src/main/resources/fdmc.mixins.json
+++ b/src/main/resources/fdmc.mixins.json
@@ -20,6 +20,7 @@
     "entity.EntityMixin",
     "entity.MobEntityMixin",
     "entity.ServerPlayerEntityMixin",
+    "math.BlockPosMutableMixin",
     "neighourupdaters.EntryMixin",
     "neighourupdaters.NeighborUpdaterMixin",
     "neighourupdaters.SixWayEntryMixin"


### PR DESCRIPTION
Adds BlockPos4.Mutable4.
Implements most 4D equivalants of Vec3i, BlockPos and BlockPos.Mutable methods.
Fixes mapping issue with the way Vec4i, BlockPos4 and BlockPos4.Mutable4 expose Vec3i, BlockPos and BlockPos.Mutable methods.