### PR TITLE
Update build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         # Use these Java versions
         java: [
-          17,    # Current Java LTS & minimum supported by Minecraft
+          17,21
         ]
         # and run on both Linux and Windows
         os: [ubuntu-20.04, windows-2022]
@@ -32,8 +32,8 @@ jobs:
       - name: build
         run: ./gradlew build
       - name: capture build artifacts
-        if: ${{ runner.os == 'Linux' && matrix.java == '17' }} # Only upload artifacts built from latest java on one OS
-        uses: actions/upload-artifact@v2
+        if: ${{ runner.os == 'Windows' && matrix.java == '21' }} # Only upload artifacts built from latest java on one OS
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: Artifacts
           path: build/libs/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         # Use these Java versions
         java: [
-          17,21
+          21
         ]
         # and run on both Linux and Windows
         os: [ubuntu-20.04, windows-2022]


### PR DESCRIPTION
Build action uses action as/upload-artifact@v4.4.3 and now builds for Java 17 and 21